### PR TITLE
Rights notice on every page, and a build check that enforces it

### DIFF
--- a/capture/vault/techniques-cassette-loading.json
+++ b/capture/vault/techniques-cassette-loading.json
@@ -4,13 +4,14 @@
   "variant": "spectrum_48k",
   "image_dir": "vault/techniques/cassette-loading",
   "note": "Captures for the cassette-loading entry. Governed by 198x/decisions/capturing-published-software.md. Media images are never published or committed; the source paths below are local.",
-
   "framing": "FULL RASTER, 352x296, nearest-neighbour x2 — deliberately NOT cropped to the 256x192 picture the way other Vault captures are. The striped border IS the subject here: it is the loading routine writing the border colour as it decodes pulses. Cropping to the active area would remove the thing the figure exists to show.",
-
   "captures": [
     {
       "id": "spectrum-loading-stripes",
       "claim": "A tape load shows its progress in the border, because the loader changes the border colour as it decodes — so the stripe pattern is a direct readout of pulses arriving off the tape.",
+      "screenshots": [
+        "spectrum-loading-stripes.png"
+      ],
       "work": {
         "title": "Sabre Wulf",
         "publisher": "Ultimate Play The Game",
@@ -26,17 +27,30 @@
         "flags": "none — clean original dump"
       },
       "timeline": [
-        {"wait": 120},
-        {"basic_load": "keyword entry: J, SymbolShift+P, SymbolShift+P, Enter"},
-        {"tape_start": true},
-        {"wait": 2600, "comment": "mid-load — stripes running, game not yet in"},
-        {"screenshot": "spectrum-loading-stripes.png"}
+        {
+          "wait": 120
+        },
+        {
+          "basic_load": "keyword entry: J, SymbolShift+P, SymbolShift+P, Enter"
+        },
+        {
+          "tape_start": true
+        },
+        {
+          "wait": 2600,
+          "comment": "mid-load — stripes running, game not yet in"
+        },
+        {
+          "screenshot": "spectrum-loading-stripes.png"
+        }
       ]
     },
-
     {
       "id": "spectrum-loading-screen",
       "claim": "A loading screen is a separate, earlier block: the picture is fully displayed while the game itself is still streaming in behind it, stripes still running.",
+      "screenshots": [
+        "spectrum-loading-screen.png"
+      ],
       "work": {
         "title": "Dizzy - The Ultimate Cartoon Adventure",
         "publisher": "Code Masters",
@@ -53,11 +67,22 @@
       },
       "block_structure": "Six standard-speed (0x10) blocks: header + BASIC loader, header + 62-byte custom loader, then two headerless data blocks — 6,914 bytes (the loading screen) and 41,803 bytes (the game). Those two sizes are what the caption's timing arithmetic is drawn from.",
       "timeline": [
-        {"wait": 120},
-        {"basic_load": "keyword entry: J, SymbolShift+P, SymbolShift+P, Enter"},
-        {"tape_start": true},
-        {"wait": 12000, "comment": "screen block in and displayed; main block still loading"},
-        {"screenshot": "spectrum-loading-screen.png"}
+        {
+          "wait": 120
+        },
+        {
+          "basic_load": "keyword entry: J, SymbolShift+P, SymbolShift+P, Enter"
+        },
+        {
+          "tape_start": true
+        },
+        {
+          "wait": 12000,
+          "comment": "screen block in and displayed; main block still loading"
+        },
+        {
+          "screenshot": "spectrum-loading-screen.png"
+        }
       ],
       "caveat": "Superseded 2026-08-14. This entry previously recorded that the dump does not complete, citing emu198x#872 as a hang on this very screen. There was no hang. #872 closed as not-a-bug: the apparent freeze was the test harness holding P, which is the game's pause key, compounded by a key sweep pressing K and so switching the game to Kempston. #874 then fixed the autoload prompt wait, and the TZX now reaches the title exactly as the TAP does. The capture and the claim were never affected either way — the loading screen block loads and displays correctly, which is all the figure illustrates — but the note as written misdescribed the emulator and is corrected here rather than deleted."
     }

--- a/capture/vault/techniques-colour-clash.json
+++ b/capture/vault/techniques-colour-clash.json
@@ -4,11 +4,13 @@
   "variant": "spectrum_48k",
   "image_dir": "vault/techniques/colour-clash",
   "note": "Captures for the Colour Clash entry. Governed by 198x/decisions/capturing-published-software.md: our own frames, from media we already hold, published as illustration inside criticism. Media images are never published or committed — the source paths below are local and resolve on no public checkout.",
-
   "captures": [
     {
       "id": "knight-lore-monochrome",
       "claim": "Knight Lore draws its rooms in a single ink, so no sprite can ever inherit a neighbouring cell's colour.",
+      "screenshots": [
+        "knight-lore-monochrome.png"
+      ],
       "work": {
         "title": "Knight Lore",
         "publisher": "Ultimate Play The Game",
@@ -24,20 +26,38 @@
         "flags": "none — clean original dump, no [cr] [h] [t] [a] modifier"
       },
       "timeline": [
-        {"wait": 120},
-        {"basic_load": "keyword entry: J, SymbolShift+P, SymbolShift+P, Enter"},
-        {"tape_start": true},
-        {"wait": 18000, "comment": "real pulse-driven ROM load"},
-        {"key": "4", "comment": "control select"},
-        {"wait": 750},
-        {"screenshot": "knight-lore-monochrome.png"}
+        {
+          "wait": 120
+        },
+        {
+          "basic_load": "keyword entry: J, SymbolShift+P, SymbolShift+P, Enter"
+        },
+        {
+          "tape_start": true
+        },
+        {
+          "wait": 18000,
+          "comment": "real pulse-driven ROM load"
+        },
+        {
+          "key": "4",
+          "comment": "control select"
+        },
+        {
+          "wait": 750
+        },
+        {
+          "screenshot": "knight-lore-monochrome.png"
+        }
       ],
       "post": "crop to the 256x192 active area at (48,48), nearest-neighbour x2"
     },
-
     {
       "id": "sabre-wulf-black-arena",
       "claim": "Sabre Wulf keeps its colour in an impassable border and leaves the playfield black, so the moving sprites never share a cell with coloured scenery.",
+      "screenshots": [
+        "sabre-wulf-black-arena.png"
+      ],
       "work": {
         "title": "Sabre Wulf",
         "publisher": "Ultimate Play The Game",
@@ -53,23 +73,46 @@
         "flags": "none — clean original dump, no [cr] [h] [t] [a] modifier"
       },
       "timeline": [
-        {"wait": 120},
-        {"basic_load": "keyword entry: J, SymbolShift+P, SymbolShift+P, Enter"},
-        {"tape_start": true},
-        {"wait": 17000, "comment": "real pulse-driven ROM load"},
-        {"key": "3", "comment": "keyboard control"},
-        {"wait": 80},
-        {"key": "0", "comment": "start game"},
-        {"wait": 200},
-        {"screenshot": "sabre-wulf-black-arena.png"}
+        {
+          "wait": 120
+        },
+        {
+          "basic_load": "keyword entry: J, SymbolShift+P, SymbolShift+P, Enter"
+        },
+        {
+          "tape_start": true
+        },
+        {
+          "wait": 17000,
+          "comment": "real pulse-driven ROM load"
+        },
+        {
+          "key": "3",
+          "comment": "keyboard control"
+        },
+        {
+          "wait": 80
+        },
+        {
+          "key": "0",
+          "comment": "start game"
+        },
+        {
+          "wait": 200
+        },
+        {
+          "screenshot": "sabre-wulf-black-arena.png"
+        }
       ],
       "post": "crop to the 256x192 active area at (48,48), nearest-neighbour x2"
     },
-
     {
       "id": "dizzy-sprite-clash-pair",
       "claim": "A sprite crossing into a cell that already holds coloured scenery is redrawn in the scenery's attribute, so one object appears in two colours at once, split on the character grid.",
-      "screenshots": ["dizzy-sprite-single-ink.png", "dizzy-sprite-two-inks.png"],
+      "screenshots": [
+        "dizzy-sprite-single-ink.png",
+        "dizzy-sprite-two-inks.png"
+      ],
       "pairing": "Both frames come from ONE jump, six frames apart, in a single uninterrupted run from the tape. In the first the airborne sprite is entirely white; in the second it has drifted left over the hut's roof edge and the two cells that overlap the roof post are drawn in the hut's ink. Nothing else about the scene changes, which is what makes the pair evidence rather than two pictures.",
       "work": {
         "title": "Dizzy - The Ultimate Cartoon Adventure",
@@ -87,28 +130,60 @@
       },
       "controls": "Z left, X right, Space jump (and 'jump to start' at the title), P pause, K Kempston. Read off the game's own key table at $E5B4 and confirmed on emu198x#872. Movement is driven as raw held key-down input, because press_key auto-releases and cannot hold a direction across a screenshot.",
       "timeline": [
-        {"tape_load": "autoload_tape, then 21000 frames of real pulse-driven ROM load"},
-        {"key": "SPACE", "frames": 10, "comment": "jump to start"},
-        {"wait": 150},
-        {"hold": "Z", "frames": 192, "comment": "walk left until the haystack stops him"},
-        {"wait": 20},
-        {"hold": "Z", "comment": "still pushing left, held across the jump"},
-        {"key": "SPACE", "frames": 8, "comment": "jump"},
-        {"wait": 18},
-        {"screenshot": "dizzy-sprite-single-ink.png"},
-        {"wait": 6},
-        {"screenshot": "dizzy-sprite-two-inks.png"},
-        {"release": "Z"}
+        {
+          "tape_load": "autoload_tape, then 21000 frames of real pulse-driven ROM load"
+        },
+        {
+          "key": "SPACE",
+          "frames": 10,
+          "comment": "jump to start"
+        },
+        {
+          "wait": 150
+        },
+        {
+          "hold": "Z",
+          "frames": 192,
+          "comment": "walk left until the haystack stops him"
+        },
+        {
+          "wait": 20
+        },
+        {
+          "hold": "Z",
+          "comment": "still pushing left, held across the jump"
+        },
+        {
+          "key": "SPACE",
+          "frames": 8,
+          "comment": "jump"
+        },
+        {
+          "wait": 18
+        },
+        {
+          "screenshot": "dizzy-sprite-single-ink.png"
+        },
+        {
+          "wait": 6
+        },
+        {
+          "screenshot": "dizzy-sprite-two-inks.png"
+        },
+        {
+          "release": "Z"
+        }
       ],
       "verification": "capture/verify-clash.py --sprite BASELINE FRAME. The first frame reports no sprite-side clash; the second reports one object spanning 8 cells, (255,255,255) in six and (194,0,0) in two. Run --self-test first: it builds a positive control for each side of the measurement.",
       "measured": "Across the single jump the sprite is drawn in three inks: its own white, the hut's non-bright red (194,0,0), and the haystack's non-bright yellow (194,194,0). Each matches the scenery it overlaps exactly, BRIGHT bit included — the cell hands over the whole attribute byte, not just the colour.",
       "post": "crop to the 256x192 active area at (48,48), nearest-neighbour x2"
     },
-
     {
       "id": "dark-sceptre-masked-sprite",
       "claim": "A masked sprite stays one colour against coloured scenery, and the scenery stops at a black margin following its outline.",
-      "screenshots": ["dark-sceptre-masked-sprite.png"],
+      "screenshots": [
+        "dark-sceptre-masked-sprite.png"
+      ],
       "work": {
         "title": "Dark Sceptre",
         "author": "Mike Singleton",
@@ -128,26 +203,40 @@
       },
       "dump_note": "The TAP dump of this title does NOT work and the choice of TZX is not incidental. Dark Sceptre shipped with BleepLoad, Firebird's custom loader; TAP is a block-level format that cannot carry custom pulse timing, so the TAP load stalls part-way through the second block with the loading screen half drawn. Anyone re-running this against the TAP (sha1 2229a2aca08f1a9594c85189d51903455b991784) will see a hang that is the format's fault, not the emulator's.",
       "timeline": [
-        {"tape_load": "autoload_tape, then 43500 frames of real pulse-driven ROM load"},
-        {"key": "K", "frames": 12, "comment": "KEYBOARD, from the game's own control menu"},
-        {"wait": 60},
-        {"key": "P", "frames": 12, "comment": "PLAY GAME"},
-        {"wait": 640},
-        {"screenshot": "dark-sceptre-masked-sprite.png"}
+        {
+          "tape_load": "autoload_tape, then 43500 frames of real pulse-driven ROM load"
+        },
+        {
+          "key": "K",
+          "frames": 12,
+          "comment": "KEYBOARD, from the game's own control menu"
+        },
+        {
+          "wait": 60
+        },
+        {
+          "key": "P",
+          "frames": 12,
+          "comment": "PLAY GAME"
+        },
+        {
+          "wait": 640
+        },
+        {
+          "screenshot": "dark-sceptre-masked-sprite.png"
+        }
       ],
       "controls": "From the game's control menu: K keyboard, J joystick, U user keys, P play game. Its key diagram shows Q/A up-down, O/P left-right, M fire. In play O and P move between warriors rather than walking one — this is a strategy game, and the scene does not animate until orders are planned.",
       "not_measured": "Masking is NOT measured here, only shown. Three attempts failed and each failed for a recorded reason. A walk sequence changed location between frames (REAPER at Gattar's Fork became HERALD at Girel's Way), so both detectors were reading a scene change: 1,037 background-side cells and 23 sprite-side objects, all void. An idle sequence produced one distinct frame in thirty, because the game does not advance without orders. A static-frame proxy counting 'cells holding both sprite and scenery ink' is tautological — a Spectrum cell holds one ink by definition, so it returns zero for a clashing frame and a masked one alike, which it duly did for both Dizzy and this. The figure is published as an illustration of what the technique looks like, not as a measurement that it is present.",
       "post": "crop to the 256x192 active area at (48,48), nearest-neighbour x2"
     }
   ],
-
   "period_sources": {
     "note": "Attribution is a press question, not an emulator question. Measurement establishes what a game does; it can never establish what the technique was called or who was credited with it. Both quotes below are from the magazine holdings in reference/contextual/magazines/.",
     "your-sinclair-008": "Preview, 1986: 'Oh, very nice. Dark Sceptre from Beyond, eh? Classy graphics. Look at the size of that mask — no attribute problems here. A Mike Singleton game? Certainly looks as though it could be as big as Lords Of Midnight.' The effect was legible on sight, before release, and read as an authorial signature.",
     "your-sinclair-039": "Review, 1989, of a different game: 'All the characters are huge, nearly one third screen height, and well detailed. They're all protected from colour clash by a thick black Dark Sceptre mask.' This is the load-bearing one — within three years the title had become the generic English name for the technique. Which game was under review is unresolved; the magazine's columns interleave badly in OCR and it does not matter to the usage.",
     "unresolved": "Whether and when the technique spread to Spanish studios cannot be sourced from these holdings, which are British. reference/contextual/magazines/source/ has no Spanish-language Spectrum press — microhobby-br is Brazilian and there is no MicroHobby (ES). That is a gap in our sources, not a finding about Spain, and MicroHobby (ES) is the obvious acquisition target."
   },
-
   "diagrams": {
     "note": "These are DRAWINGS, not captures. They illustrate the mechanism; they are not evidence that anything happened on real hardware. The entry marks the distinction three ways — no Spectrum bezel (frame=\"none\" where the captures use frame=\"spectrum\"), a diagram- filename prefix, and a caption opening with \"Diagram\" — because a page whose other figures are frames from real tapes cannot afford a reader mistaking one for the other.",
     "generator": "capture/vault/diagrams.py — re-run to regenerate all four identically. Hand-drawn PNGs were rejected: the capture manifests record exactly how every published frame was reached, and a diagram should be no less reproducible.",
@@ -158,22 +247,33 @@
       "negative — baseline -> masked flags nothing. A detector that flags everything also 'finds' clash, and is exactly as useless as one that flags nothing."
     ],
     "figures": [
-      {"file": "diagram-attribute-byte.png", "section": "The attribute system", "shows": "one byte governing all 64 pixels of a cell regardless of what drew them"},
-      {"file": "diagram-clash-mechanism.png", "section": "Why it happens", "shows": "three pixels of movement repainting two whole cells — movement is measured in pixels, colour in cells"},
-      {"file": "diagram-clash-two-sides.png", "section": "Why it happens", "shows": "the same collision resolved both ways: intruder wins, or standing art wins and the sprite is recoloured"},
-      {"file": "diagram-sprite-masking.png", "section": "Mitigation strategies", "shows": "a black surround keeping a sprite out of shared cells, and the hole it punches in the scenery"}
+      {
+        "file": "diagram-attribute-byte.png",
+        "section": "The attribute system",
+        "shows": "one byte governing all 64 pixels of a cell regardless of what drew them"
+      },
+      {
+        "file": "diagram-clash-mechanism.png",
+        "section": "Why it happens",
+        "shows": "three pixels of movement repainting two whole cells — movement is measured in pixels, colour in cells"
+      },
+      {
+        "file": "diagram-clash-two-sides.png",
+        "section": "Why it happens",
+        "shows": "the same collision resolved both ways: intruder wins, or standing art wins and the sprite is recoloured"
+      },
+      {
+        "file": "diagram-sprite-masking.png",
+        "section": "Mitigation strategies",
+        "shows": "a black surround keeping a sprite out of shared cells, and the hole it punches in the scenery"
+      }
     ]
   },
-
   "findings": {
     "black-paper-was-near-universal": "Every game screened puts its sprites on black paper: Manic Miner (Bug-Byte 1983), sprites on the top row of a platform rather than overlapping filled colour; Sabre Wulf (Ultimate 1984), black arena with the colour in an impassable border; Knight Lore (Ultimate 1984), one ink per room; Auf Wiedersehen Monty (Gremlin 1987), coloured scenery but sprites against black paper; Ghosts 'n Goblins (Elite 1986), filled green ground but the sprites above it in different cell rows. The entry lists 'black backgrounds common' as one mitigation among four; on this evidence it was closer to universal. Dizzy is no exception — its first location is entirely coloured ink on black paper, with not one cell carrying a non-black paper.",
-
     "which-side-gets-repainted": "Clash has two sides and they need different instruments. BACKGROUND SIDE: the intruder wins the cell and standing art changes colour under it — measurable by pairing frames, since art that keeps its shape and changes colour was repainted. SPRITE SIDE: the standing art wins and the intruder is repainted, which is the famous form and the one captured here. The pair test is blind to it by construction, because it only considers pixels lit in both frames and a moving sprite's pixels never coincide with themselves.",
-
     "the-player-does-clash": "An earlier pass concluded the opposite — that the player sprite never clashes and only the spider's thread does — on the strength of a background-side sweep returning zero across roughly 200 frames in five sequences. That sweep was correct and its result stands: on this screen no standing art is ever repainted by the player. It was the wrong question. The sprite-side test finds 157 multi-ink objects across the same frames.",
-
     "background-side-on-this-screen": "The only standing art ever repainted on Dizzy's first location is the spider's thread, where the descending spider's cell takes the thread's white for one cell and gives it back on the way past. It happens identically with no input at all, so it is the spider's animation cycle rather than anything the player did."
   },
-
   "process_note": "Three frames were rejected in the first session: two for appearing to show clash and not surviving a close read, one for a misidentified sprite. Captions must describe what is structurally visible and must not name characters, which proved unreliable at this resolution — the work itself is still named in full (title, publisher, year, platform) as the licensing decision requires. Added after the second session: a sound, self-testing instrument used outside its range returns a confident negative indistinguishable from a true one. Check that the test can see the artefact being asked about before believing it cannot find one."
 }

--- a/capture/vault/techniques-isometric-projection.json
+++ b/capture/vault/techniques-isometric-projection.json
@@ -4,11 +4,13 @@
   "variant": "spectrum_48k",
   "image_dir": "vault/techniques/isometric-projection",
   "note": "Capture for the isometric-projection entry. Governed by 198x/decisions/capturing-published-software.md. Media images are never published or committed.",
-
   "captures": [
     {
       "id": "knight-lore-2to1-steps",
       "claim": "The 2:1 ratio is directly countable in the pixels: a receding edge steps two across for every one down.",
+      "screenshots": [
+        "knight-lore-2to1-steps.png"
+      ],
       "work": {
         "title": "Knight Lore",
         "publisher": "Ultimate Play The Game",
@@ -24,25 +26,44 @@
         "flags": "none — clean original dump"
       },
       "timeline": [
-        {"wait": 120},
-        {"basic_load": "keyword entry: J, SymbolShift+P, SymbolShift+P, Enter"},
-        {"tape_start": true},
-        {"wait": 18000},
-        {"key": "1", "comment": "KEYBOARD on the control menu"},
-        {"wait": 120},
-        {"key": "0", "comment": "START GAME"},
-        {"wait": 400},
-        {"screenshot": "kg-start.png"}
+        {
+          "wait": 120
+        },
+        {
+          "basic_load": "keyword entry: J, SymbolShift+P, SymbolShift+P, Enter"
+        },
+        {
+          "tape_start": true
+        },
+        {
+          "wait": 18000
+        },
+        {
+          "key": "1",
+          "comment": "KEYBOARD on the control menu"
+        },
+        {
+          "wait": 120
+        },
+        {
+          "key": "0",
+          "comment": "START GAME"
+        },
+        {
+          "wait": 400
+        },
+        {
+          "screenshot": "kg-start.png"
+        }
       ],
       "post": "crop raw (150,60)-(244,122), nearest-neighbour x7",
-
+      "two_stage": "This capture is two-stage, unlike the others: the timeline writes a full raw frame as kg-start.png, and `post` crops that into the published knight-lore-2to1-steps.png. kg-start.png is an intermediate and is never published, which is why `screenshots` names what is published rather than leaving it to be inferred from the timeline.",
       "measurement": {
         "why": "The claim is quantitative, so it was measured rather than eyeballed — the standing rule for this entry set after three frames were rejected in the first capture session for looking right and not being right.",
         "method": "Count horizontal runs of lit pixels that begin a fresh edge (lit at y, unlit at y-1) across the room area only, excluding the HUD below y=166. A 2:1 staircase produces a strong mode at run length 2.",
         "result": "642 leading-edge runs; 321 of length 2 (50%), next most common length 4 at 65 (10%).",
         "verdict": "Confirms the 2:1 stepping. Note the search was deliberately restricted to room geometry: the longest clean 2:1 staircase in the whole frame is the HUD divider line, which is drawn at the same angle but is not projected world geometry and would have been dishonest to caption as such."
       },
-
       "crop_selection": "The crop point was found programmatically — the longest run of consistent two-across-one-down stepping within the room area — rather than chosen by eye."
     }
   ]

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build && node scripts/mark-redirects-noindex.mjs && pagefind --site dist",
+    "build": "node scripts/check-vault-imagery.mjs && astro build && node scripts/mark-redirects-noindex.mjs && pagefind --site dist",
+    "check:imagery": "node scripts/check-vault-imagery.mjs",
     "preview": "astro preview",
     "astro": "astro",
     "test:e2e": "playwright test",

--- a/scripts/check-vault-imagery.mjs
+++ b/scripts/check-vault-imagery.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+/**
+ * Fail the build if published Vault imagery breaks the family's imagery rules.
+ *
+ * Two umbrella decisions govern what may appear on a Vault page:
+ *   198x/decisions/capturing-published-software.md
+ *   198x/decisions/publishing-third-party-imagery.md
+ *
+ * Both are written down, and until now nothing enforced either. The first one
+ * names that gap as its own design principle — "a rule the format enforces
+ * beats a rule people have to remember ... the ones that depend on remembering
+ * are the ones that fail in two years when someone adds one more capture."
+ * This is that enforcement.
+ *
+ * What it checks
+ * -------------
+ *  1. Every image under public/images/vault/ is claimed by a capture manifest.
+ *     An unclaimed image is one whose provenance nobody recorded, which is the
+ *     precise failure "provenance is recorded, not assumed" exists to prevent.
+ *  2. Every image a manifest claims actually exists. A manifest describing a
+ *     frame that is not there is a provenance record for nothing.
+ *  3. Anything declared `"class": "cover-art"` stays within the size ceiling,
+ *     is one per entry, and names a rights-holder. Resolution is the fairness
+ *     argument for cover art, so it is the one thing worth measuring rather
+ *     than trusting.
+ *
+ * It deliberately does NOT check captions, acknowledgement wording, or whether
+ * an image earns its place. Those are editorial and a script would only give
+ * false confidence about them.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative, extname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+const MANIFEST_DIR = join(ROOT, 'capture/vault');
+const IMAGE_ROOT = join(ROOT, 'public/images');
+const VAULT_IMAGES = join(IMAGE_ROOT, 'vault');
+
+const IMAGE_EXT = new Set(['.png', '.jpg', '.jpeg', '.webp', '.gif', '.avif']);
+
+/**
+ * Cover art ceiling, in total pixels.
+ *
+ * publishing-third-party-imagery.md requires cover art to be "large enough to
+ * see what the artwork is, too small to serve as a reproduction of it" without
+ * fixing a number, so the number lives here where it can be enforced. 100,000
+ * pixels is roughly 400x250 — comfortably legible on a page, useless as a
+ * reproduction of a painting. Our own captures are 512x384 (196,608) and are
+ * NOT subject to this: they are our frames, not somebody's artwork.
+ */
+const MAX_COVER_PIXELS = 100_000;
+
+const problems = [];
+const fail = (msg) => problems.push(msg);
+
+function walk(dir) {
+  let out = [];
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name);
+    if (statSync(path).isDirectory()) out = out.concat(walk(path));
+    else if (IMAGE_EXT.has(extname(name).toLowerCase())) out.push(path);
+  }
+  return out;
+}
+
+/**
+ * What a manifest publishes, declared rather than inferred.
+ *
+ * Inferring this from "any string that looks like a filename" was the first
+ * thing tried and it is wrong, because a capture can be two-stage: the
+ * timeline writes a raw frame and `post` crops that into the published image,
+ * so the timeline's filename names an intermediate that is never published.
+ * Guessing conflates the two in both directions — it demands a file that
+ * should not exist, and lets a real published image go unclaimed.
+ *
+ * So a capture states its published images in `screenshots` (or `image`), and
+ * a diagram block states its own in `figures[].file`. Everything else in the
+ * manifest — raw intermediates, dump filenames — is prose to this check.
+ */
+function publishedNames(data, found = new Set()) {
+  for (const capture of data.captures ?? []) {
+    for (const name of [capture.screenshots, capture.image].flat().filter(Boolean)) {
+      found.add(name);
+    }
+  }
+  for (const figure of data.diagrams?.figures ?? []) {
+    if (figure.file) found.add(figure.file);
+  }
+  return found;
+}
+
+/** PNG dimensions from the IHDR chunk — avoids taking on an image dependency. */
+function pngSize(path) {
+  const buf = readFileSync(path);
+  const isPng = buf.length > 24 && buf.readUInt32BE(0) === 0x89504e47;
+  if (!isPng) return null;
+  return { width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) };
+}
+
+const manifests = readdirSync(MANIFEST_DIR).filter((f) => f.endsWith('.json'));
+if (manifests.length === 0) fail(`No capture manifests found in ${relative(ROOT, MANIFEST_DIR)}`);
+
+const claimedPaths = new Map();          // absolute image path -> manifest name
+
+for (const file of manifests) {
+  const manifestPath = join(MANIFEST_DIR, file);
+  let data;
+  try {
+    data = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  } catch (err) {
+    fail(`${file}: not valid JSON — ${err.message}`);
+    continue;
+  }
+
+  if (!data.image_dir) {
+    fail(`${file}: no "image_dir", so its images cannot be located`);
+    continue;
+  }
+
+  const published = publishedNames(data);
+  if (published.size === 0) {
+    fail(`${file}: declares no published images. Each capture needs "screenshots" (or "image").`);
+  }
+
+  for (const name of published) {
+    const abs = join(IMAGE_ROOT, data.image_dir, name);
+    try {
+      statSync(abs);
+    } catch {
+      fail(`${file}: claims ${name}, which does not exist at images/${data.image_dir}/${name}`);
+      continue;
+    }
+    const already = claimedPaths.get(abs);
+    if (already && already !== file) {
+      fail(`${name} is claimed by both ${already} and ${file} — provenance must have one home`);
+    }
+    claimedPaths.set(abs, file);
+  }
+
+  // Cover art carries limits the rest of the imagery does not.
+  const covers = (data.captures ?? []).filter((c) => c.class === 'cover-art');
+  if (covers.length > 1) {
+    fail(`${file}: ${covers.length} cover-art entries; the limit is one per entry`);
+  }
+  for (const cover of covers) {
+    const names = [cover.screenshots, cover.image].flat().filter(Boolean);
+    if (names.length > 1) {
+      fail(`${file}: cover-art "${cover.id}" carries ${names.length} images; the limit is one`);
+    }
+    if (!cover.work?.artist && !cover.work?.artist_unknown) {
+      fail(
+        `${file}: cover-art "${cover.id}" names no artist. Set work.artist, or ` +
+        `work.artist_unknown describing where you looked — "unknown" is a claim about our research.`
+      );
+    }
+    for (const name of names) {
+      const abs = join(IMAGE_ROOT, data.image_dir, name);
+      const size = pngSize(abs);
+      if (!size) continue;                       // non-PNG: size unchecked, flagged below
+      const pixels = size.width * size.height;
+      if (pixels > MAX_COVER_PIXELS) {
+        fail(
+          `${name}: ${size.width}x${size.height} = ${pixels.toLocaleString()} pixels, over the ` +
+          `${MAX_COVER_PIXELS.toLocaleString()} ceiling for cover art. Resolution is the ` +
+          `fairness argument — shrink it rather than raising the limit.`
+        );
+      }
+    }
+  }
+}
+
+let onDisk = [];
+try {
+  onDisk = walk(VAULT_IMAGES);
+} catch {
+  // No Vault imagery yet is a valid state.
+}
+
+for (const path of onDisk) {
+  if (!claimedPaths.has(path)) {
+    fail(
+      `images/${relative(IMAGE_ROOT, path)} is published but no manifest claims it. ` +
+      `Record where it came from in capture/vault/, or remove it.`
+    );
+  }
+}
+
+if (problems.length) {
+  console.error(`\nVault imagery check failed (${problems.length}):\n`);
+  for (const p of problems) console.error(`  · ${p}`);
+  console.error(
+    '\nSee 198x/decisions/publishing-third-party-imagery.md and ' +
+    'capturing-published-software.md.\n'
+  );
+  process.exit(1);
+}
+
+console.log(`Vault imagery: ${onDisk.length} image(s) across ${manifests.length} manifest(s), all accounted for.`);

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -244,6 +244,11 @@ const ogImageUrl = new URL(image, siteUrl).href;
         <div class="footer-bottom">
           <p>© 2025–{new Date().getFullYear()} Code Like It's 198x</p>
           <p class="footer-credits">Open source • Made with care for retro computing</p>
+          <p class="footer-rights">
+            Games, artwork, logos and trademarks remain the property of their respective owners
+            and are reproduced here to illustrate criticism and review.{' '}
+            <a href="/standards#rights">Rights &amp; attribution</a>
+          </p>
         </div>
       </div>
     </footer>
@@ -1011,6 +1016,22 @@ const ogImageUrl = new URL(image, siteUrl).href;
 
   .footer-credits {
     font-size: 0.8125rem;
+  }
+
+  /* Standing rights notice — required on every public surface carrying imagery
+     by 198x/decisions/publishing-third-party-imagery.md. Full-width so it reads
+     as a statement rather than a footer credit sitting beside the copyright. */
+  .footer-rights {
+    flex-basis: 100%;
+    font-size: 0.75rem;
+    line-height: 1.5;
+    opacity: 0.75;
+  }
+
+  .footer-rights a {
+    color: inherit;
+    text-decoration: underline;
+    white-space: nowrap;
   }
 
   @media (max-width: 768px) {

--- a/src/pages/standards.astro
+++ b/src/pages/standards.astro
@@ -179,6 +179,34 @@ const evidenceLabels = [
       </div>
     </section>
 
+    <section class="band split" id="rights">
+      <div>
+        <p class="kicker">Imagery, marks and attribution</p>
+        <h2>Everything shown here belongs to whoever made it.</h2>
+        <p>
+          Screenshots and clips on this site are our own captures, taken from media we already
+          hold, and published as illustration inside criticism. Company names, logos and
+          trademarks are reproduced to identify the companies an entry is about. Cover art,
+          inlays and book covers are reproduced small, one per entry, to illustrate a claim the
+          entry is making — never as a substitute for the work itself.
+        </p>
+        <p>
+          <strong>
+            All games, artwork, logos, trademarks and photographs remain the property of their
+            respective owners. Nothing reproduced here is claimed as our work, and no endorsement
+            or affiliation is implied.
+          </strong>{' '}
+          Where an artist, author or photographer is known, we name them. Where a rights-holder
+          would prefer something removed, we remove it on request, without argument.
+        </p>
+      </div>
+      <div class="checks">
+        <div><Camera size={20} /><span>Our own capture, from media we hold</span></div>
+        <div><Scale size={20} /><span>Small, and tied to a claim on the page</span></div>
+        <div><FileSearch size={20} /><span>Named artist wherever we can establish one</span></div>
+      </div>
+    </section>
+
     <section class="band split">
       <div>
         <p class="kicker">Emulator versus hardware</p>
@@ -229,6 +257,9 @@ const evidenceLabels = [
   .links { display: grid; gap: var(--space-3); }
   .links a { color: var(--ink); font-weight: 700; text-decoration: none; }
   .links a:hover { border-color: var(--color-house-2); }
+  /* Every other band carries a single paragraph, so band <p> has no margin.
+     The rights notice needs two: the statement, then the practice. */
+  #rights p + p { margin-top: var(--space-4); }
   @media (max-width: 920px) { .ladder, .valid-grid, .labels { grid-template-columns: repeat(2, 1fr); } .split { grid-template-columns: 1fr; } }
   @media (max-width: 620px) { .ladder, .rules, .valid-grid, .labels { grid-template-columns: 1fr; } .band-head { display: block; } .band-url { display: block; margin-top: var(--space-1); } }
 </style>


### PR DESCRIPTION
Makes `198x/decisions/publishing-third-party-imagery.md` real on this site. That decision permits company logos and low-resolution cover art, and requires a standing rights notice on every public surface carrying imagery. The site had none, and nothing enforced any of it.

## The notice

A line in the footer, so it appears on every page including the 1,379 Vault entries, plus a section on `/standards#rights` beside the existing "show the result, do not ship what is not ours" band.

It does not claim fair dealing anywhere on the page. It states what the images are, that nothing is claimed as our work, that no endorsement is implied, that we name artists where we can, and that anything comes down on request. Those are what a rights-holder wants to read; the legal reasoning belongs in the decision record, not the footer.

## The check

`scripts/check-vault-imagery.mjs`, first in the build chain so it fails before Astro starts. `capturing-published-software.md` names this gap as its own design principle — *"a rule the format enforces beats a rule people have to remember … the ones that depend on remembering are the ones that fail in two years when someone adds one more capture."* Cover art becoming permissible is exactly when the remembering starts to fail.

It enforces three things and deliberately no more:

- every published image is claimed by a manifest
- every claimed image exists
- anything declared `cover-art` stays within 100,000 pixels (~400×250), is one per entry, and names an artist

It does not check captions or whether an image earns its place. Those are editorial, and a script asserting them would only give false confidence.

## What it caught immediately

Inferring published images from "any string that looks like a filename" is wrong. The isometric-projection capture is two-stage: the timeline writes a raw frame as `kg-start.png`, and `post` crops that into the published `knight-lore-2to1-steps.png`. Guessing conflated the two in both directions — demanding a file that should not exist while letting a real published image go unclaimed.

So manifests now declare what they publish in `screenshots`, placed after `claim` so a capture reads: the claim, then what illustrates it, then how it was reached. All three manifests updated; the two-stage case is written down where it will be read.

## Verification

- Checker broken three ways on purpose — unclaimed image, oversized cover, cover with no artist. Each fails with the reason and a pointer to the decision.
- Full build green; notice confirmed rendering on both a Vault entry and the homepage.
- Two rendering bugs found by looking rather than trusting the build: Astro trims whitespace before an inline element, so "review.Rights & attribution" and "implied.Where an artist" ran together until an explicit `{' '}` went in; and band paragraphs carry no margin because every other band has exactly one.