### PR TITLE
Say how our own name and logo may be used

### DIFF
--- a/src/pages/press.astro
+++ b/src/pages/press.astro
@@ -161,6 +161,38 @@ const facts = [
       </div>
     </section>
 
+    <!-- ============ MARKS ============ -->
+    <section class="band" id="marks">
+      <p class="aud">Using our name and logo</p>
+      <h2>You do not need to ask.</h2>
+      <p class="intro">Write about the project, talk about it, teach from it, link to it, say you
+        built something with it. Reproduce the logo unaltered, at any size, to refer to us. That is
+        what a mark is for, and it is the same test we apply to everybody else's marks when they
+        appear in the <a href="/vault">Vault</a>.</p>
+      <div class="marks-grid">
+        <div class="marks-col">
+          <p class="marks-h">Fine, unasked</p>
+          <ul>
+            <li>Articles, talks, videos, reading lists, links</li>
+            <li>Saying you built something with it, or taught from it</li>
+            <li>The logo unaltered, at any size</li>
+          </ul>
+        </div>
+        <div class="marks-col">
+          <p class="marks-h">Not fine</p>
+          <ul>
+            <li>Implying we endorse, partnered with, or approved you</li>
+            <li>Recolouring, restyling or cropping the mark</li>
+            <li>Using it as your own branding or site furniture</li>
+            <li>Any use suggesting we made your thing</li>
+          </ul>
+        </div>
+      </div>
+      <p class="foot">This is permission to refer to us, not a copyright licence on the artwork —
+        a mark we could not withdraw from a misuse would not be much of a mark. If you want
+        something outside this, Discord reaches a real person and the answer is usually yes.</p>
+    </section>
+
     <!-- ============ CONTACT ============ -->
     <section class="band">
       <p class="aud">Links and contact</p>
@@ -253,6 +285,14 @@ const facts = [
   .card strong, .block strong, .intro strong { color: var(--color-text); }
 
   .foot { margin-top: var(--space-5); font-size: 0.92rem; color: var(--color-text-secondary); }
+
+  /* Marks policy — two columns so "fine" and "not fine" are read together
+     rather than as a list someone stops halfway down. */
+  .marks-grid { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-6); margin-top: var(--space-5); }
+  .marks-h { font-family: var(--font-family-mono); font-size: 0.72rem; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; color: var(--color-text-secondary); margin: 0 0 var(--space-2); }
+  .marks-col ul { margin: 0; padding-left: 1.1rem; }
+  .marks-col li { font-size: 0.94rem; margin-bottom: var(--space-1); }
+  @media (max-width: 720px) { .marks-grid { grid-template-columns: 1fr; } }
 
   @media (max-width: 860px) {
     .cards, .two, .facts, .links { grid-template-columns: 1fr; }

--- a/src/pages/standards.astro
+++ b/src/pages/standards.astro
@@ -197,7 +197,9 @@ const evidenceLabels = [
             or affiliation is implied.
           </strong>{' '}
           Where an artist, author or photographer is known, we name them. Where a rights-holder
-          would prefer something removed, we remove it on request, without argument.
+          would prefer something removed, we remove it on request, without argument. Our own marks
+          are governed by the same test, and you do not need to ask —
+          see <a href="/press#marks">using our name and logo</a>.
         </p>
       </div>
       <div class="checks">


### PR DESCRIPTION
`publishing-third-party-imagery.md` sets a test for reproducing other people's marks: **a mark may be used to identify the thing it belongs to.** Our own marks were undefined, which left the project applying a rule to Ultimate and Ocean that it had never accepted for itself.

So: the same test, pointed at us, with the same four prohibitions in the same order.

| Fine, unasked | Not fine |
|---|---|
| Articles, talks, videos, reading lists, links | Implying we endorse, partnered with, or approved you |
| Saying you built something with it, or taught from it | Recolouring, restyling or cropping the mark |
| The logo unaltered, at any size | Using it as your own branding or site furniture |
| | Any use suggesting we made your thing |

The symmetry is the substance rather than a flourish. A project that reproduces other people's marks under a rule it would not accept for its own has not written a rule, it has written an exemption.

**Deliberately not a copyright licence on the artwork.** CC grants are irrevocable, and a mark we could not withdraw from a misuse would not be much of a mark. This is permission to refer to us; anything beyond it is a conversation.

It lives on `/press` because that is where journalists and conference organisers look — the people who would otherwise write to ask, or more likely just not use it. `/standards#rights` links across, so the page describing how we treat everybody else's marks now says what happens to ours.

Verified in the browser at `/press#marks`; build green including the imagery check.