### PR TITLE
Move Sabre Wulf to the strategy it actually uses

### DIFF
--- a/capture/vault/techniques-attribute-aware-design.json
+++ b/capture/vault/techniques-attribute-aware-design.json
@@ -1,0 +1,36 @@
+{
+  "entry": "vault/techniques/attribute-aware-design",
+  "machine": "sinclair-zx-spectrum",
+  "variant": "spectrum_48k",
+  "image_dir": "vault/techniques/attribute-aware-design",
+  "note": "A measurement record, not a capture set. This entry was corrected by measuring a claim it already made; no new frame was needed, because the figure it wanted already exists and is recorded in techniques-colour-clash.json. Governed by 198x/decisions/capturing-published-software.md.",
+
+  "measurements": [
+    {
+      "id": "sabre-wulf-step-size",
+      "tested_claim": "Strategy 2, 'Block alignment': \"Force all moving sprites to occupy whole 8x8 cells. The sprite snaps to the grid ... Atic Atac and Sabre Wulf both use cell-aligned movement and avoid clash by snapping.\"",
+      "verdict": "FALSE for Sabre Wulf. The player sprite moves three pixels per frame and stands on positions that are almost never cell boundaries.",
+      "work": {
+        "title": "Sabre Wulf",
+        "publisher": "Ultimate Play The Game",
+        "year": 1984,
+        "platform": "ZX Spectrum 48K"
+      },
+      "dump": {
+        "name": "Sabre Wulf (1984)(Ultimate Play The Game).tap",
+        "format": "tap",
+        "collection": "TOSEC",
+        "tosec_path": "Sinclair/ZX Spectrum/Games/[TAP]",
+        "sha1": "82598f8e61831b255f31ca0e6943f86872b1ed27",
+        "flags": "none — clean original dump"
+      },
+      "controls": "The game's menu offers 1/2 PLAYER, 3 KEYBOARD, 4 KEMPSTON, 5 CURSOR JOYSTICK, 6 INTERFACE II, 0 START. There is no define-keys step, so KEYBOARD uses a fixed mapping the menu never states. CURSOR JOYSTICK was chosen instead precisely because its mapping IS known and fixed: 5 left, 6 down, 7 up, 8 right. Each direction was confirmed individually before measuring rather than swept, after a key sweep caused a false 'hang' finding on emu198x#872.",
+      "method": "Load the tape, select 1 PLAYER then CURSOR JOYSTICK then START, settle, then hold 5 (left) and screenshot EVERY frame for 60 frames. The player is the only pure-white object inside the arena, so his left edge is the minimum x of white pixels within the playfield.",
+      "result": "Left edge per frame: 120, 120, 120, 120, 120, 119, 117, 115, 112, 109, 107, 103, 100, 97, 94, 91, 88, 85, 82, 79, 76, 73, 70, 67, 64, 61, 58, then held at 58 against an obstacle. Per-frame deltas are -1, -2, -3 and -4; the sustained rate is three pixels per frame. Of the 24 distinct positions occupied, only 120, 88, 64 and 112 fall on an 8-pixel boundary — the rest are mid-cell.",
+      "what_it_means": "Sabre Wulf does not avoid clash by snapping to the grid. It avoids clash the way techniques-colour-clash.json already records with a published frame: the playfield is black and every colour is pushed out into an impassable border, so a sprite moving at three pixels per frame never shares a cell with anything coloured. The mechanism named in the entry and the mechanism the game uses are different mechanisms.",
+      "not_tested": "Atic Atac is named in the same sentence and was NOT measured. It may well snap; nothing here says otherwise, and the entry's correction is scoped to the title that was checked."
+    }
+  ],
+
+  "figure": "The entry now shows sabre-wulf-black-arena.png, which already existed and is recorded in full — dump, SHA-1, timeline — in techniques-colour-clash.json. One frame, one provenance record, two entries making different claims about it. Recapturing the same frame into a second directory would have duplicated the artefact and split its provenance."
+}

--- a/scripts/check-vault-imagery.mjs
+++ b/scripts/check-vault-imagery.mjs
@@ -133,8 +133,16 @@ for (const file of manifests) {
   }
 
   const published = publishedNames(data);
-  if (published.size === 0) {
-    fail(`${file}: declares no published images. Each capture needs "screenshots" (or "image").`);
+  // A capture that publishes nothing is a capture nobody can find. A MANIFEST
+  // that publishes nothing is fine and useful: an entry may be corrected by
+  // measurement alone, with the record explaining what was measured and what
+  // it changed, and no new frame to show for it.
+  for (const capture of data.captures ?? []) {
+    const names = [capture.screenshots, capture.image].flat().filter(Boolean);
+    if (names.length === 0) {
+      fail(`${file}: capture "${capture.id}" declares no images. Add "screenshots", ` +
+           `or move it out of "captures" if it published nothing.`);
+    }
   }
 
   for (const name of published) {

--- a/src/content/vault/techniques/attribute-aware-design.mdx
+++ b/src/content/vault/techniques/attribute-aware-design.mdx
@@ -11,6 +11,8 @@ originated: 1982
 
 ---
 
+import Figure from '@components/Figure.astro';
+
 ## Overview
 
 The ZX Spectrum's video hardware uses a separate **attribute memory** region (`$5800-$5AFF`) where each 8×8 character cell holds a single byte controlling its colour: 3 bits INK (foreground), 3 bits PAPER (background), 1 bit BRIGHT, 1 bit FLASH. Two colours per cell, no more, no fewer. The pixel data at `$4000-$57FF` says *which* pixels are lit; the attribute byte says *what colour* they're rendered as.
@@ -31,9 +33,18 @@ For arcade-style games with moving multi-colour sprites, naive renderers were co
 
 **1. Monochrome rooms.** Every cell in a given scene has the same INK and PAPER attribute. The sprite can move anywhere; clash is impossible because every cell already has the sprite's colour scheme. *Knight Lore* (Ultimate, 1984) is the canonical example: every isometric room is a single ink colour on black PAPER, with the sprite's pixels rendered in that one colour. The visual cost is reduced colour variety per scene; the gain is uncompromised motion and isometric occlusion.
 
-**2. Block alignment.** Force all moving sprites to occupy whole 8×8 cells. The sprite snaps to the grid; cell attributes change cleanly as the sprite moves cell-by-cell rather than smoothly. *Atic Atac* and *Sabre Wulf* both use cell-aligned movement and avoid clash by snapping. The cost is choppy motion; the gain is clean colour transitions.
+**2. Block alignment.** Force all moving sprites to occupy whole 8×8 cells. The sprite snaps to the grid; cell attributes change cleanly as the sprite moves cell-by-cell rather than smoothly. *Atic Atac* moves this way. The cost is choppy motion; the gain is clean colour transitions.
 
 **3. Colour zones.** Divide the screen into regions with consistent attribute schemes. *Manic Miner*'s individual caverns use this: each room is painted in a few specific INK colours against a black PAPER, with sprites designed to match the room's palette. Sprites moving within a zone don't trigger clash; sprites crossing zones do.
+
+*Sabre Wulf* takes the idea to its limit: the entire playfield is black and every colour is pushed out into an impassable border. The player moves smoothly, three pixels per frame and mid-cell most of the time, and never meets a coloured cell to clash with.
+
+<Figure
+  src="/images/vault/techniques/colour-clash/sabre-wulf-black-arena.png"
+  alt="A Sabre Wulf screen: a dense border of multicoloured jungle foliage surrounding a completely black central arena, with a small white figure near the middle."
+  frame="spectrum"
+  caption="Sabre Wulf (Ultimate Play The Game, 1984, ZX Spectrum). All the colour is in the border, which cannot be entered; the arena the player moves through is black. Captured from the original tape."
+/>
 
 **4. Bitmap-only motion (no attribute change).** The sprite renderer changes ONLY the bitmap bytes at `$4000-$57FF`, never the attribute bytes at `$5800-$5AFF`. The sprite "wears" whatever colour the background already had. *Shadowkeep* uses this approach: the hero's INK/PAPER stays whatever the underlying floor was (white floor + black ink). The cost: the sprite cannot have its own colour independent of the cell it's in.
 


### PR DESCRIPTION
The entry listed *Sabre Wulf* under **block alignment** — sprites snapping to whole 8×8 cells, avoiding clash because they never half-occupy one. It doesn't do that.

## Measured

Load the tape, select `CURSOR JOYSTICK` so the key mapping is known rather than guessed, hold left, screenshot every frame. The player's left edge:

```
120, 119, 117, 115, 112, 109, 107, 103, 100, 97, 94, 91, 88, 85, 82, 79, 76, 73, 70, 67, 64, 61, 58
```

Three pixels per frame. Four of twenty-four positions land on an 8-pixel boundary. He moves smoothly and stands mid-cell most of the time.

## What he does instead

Never meet a coloured cell. Sabre Wulf's whole playfield is black with every colour pushed out into an impassable border — the colour-zone strategy taken to its limit, so that's where it now sits.

The frame illustrating it already existed for the colour-clash entry. One capture, one provenance record, two entries making different claims about it, rather than a duplicate shot into a second directory.

*Atic Atac* was named in the same sentence and has **not** been measured, so it stays.

## Notes

- The manifest records the measurement, the method, and the control menu's shape: there is no define-keys step, so `KEYBOARD` uses a fixed mapping the game never states, which is why `CURSOR JOYSTICK` was chosen. Each direction was confirmed individually rather than swept, after a key sweep produced a false "hang" finding on emu198x#872.
- Also fixes a false positive in the imagery check that this surfaced: it required every *manifest* to publish an image, so a manifest recording a correction with no new frame failed the build. The requirement belongs on captures — a capture publishing nothing can't be found, but an entry corrected by measurement alone has nothing to show and should still be recorded.